### PR TITLE
fix: App crashea debido a que falta prettier como devDependence en package.json

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,10 +1,14 @@
 module.exports = {
   root: true,
-  parser: '@typescript-eslint/parser',
-  plugins: ['@typescript-eslint'],
+  parser: "@typescript-eslint/parser",
+  plugins: ["@typescript-eslint"],
   extends: [
-    'eslint:recommended',
-    'plugin:@typescript-eslint/recommended',
-    'prettier',
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "prettier",
   ],
-}
+  env: {
+    browser: true,
+    node: true,
+  },
+};

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.25.0",
     "@typescript-eslint/parser": "^4.25.0",
+    "eslint-config-prettier": "^8.3.0",
     "eslint-config-react-app": "^6.0.0",
     "eslint-import-resolver-typescript": "^2.4.0",
     "eslint-plugin-prettier": "^3.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4502,6 +4502,11 @@ escodegen@^1.14.1:
   optionalDependencies:
     source-map "~0.6.1"
 
+eslint-config-prettier@^8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz#f7471b20b6fe8a9a9254cc684454202886a2dd7a"
+  integrity sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==
+
 eslint-config-react-app@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/eslint-config-react-app/-/eslint-config-react-app-6.0.0.tgz#ccff9fc8e36b322902844cbd79197982be355a0e"


### PR DESCRIPTION
## PR Area

<!-- Comprobrar las areas que cubre su PR utilizando "x", ELIMINAR otras -->

- [x] Frontend

## Tipo de cambio

_Que tipo de cambio introduce este PR?_

<!-- Marque los que se aplican a este PR utilizando "x", ELIMINAR otras -->

- [x] Bugfix

## Descripcion

<!-- Añadir algunos puntos * que describan los cambios introducidos -->
Cuando queremos iniciar la aplicacion, React no levanta porque no encuentra prettier como devDependence. Para solucionar esto se hizo lo siguiente:
- Agregado prettier plugin como dev dependencies que estaba faltando en package.json
- Agregado soporte para `node` y `browser`, especificandolos en `env` dentro de ESLint config (esto evita que ESLint muestre `'module' is not defined.eslintno-undef` )

#### Capturas de pantalla

<!-- Por favor, arrastre y suelte para subir capturas de pantalla de la UI que es nueva o tiene grandes cambios  -->

## Reviewer checklist

- [ ] He ejecutado el codigo (si es aplicable)
- [ ] He revisado y ejecutado unit tests (si es aplicable)
